### PR TITLE
Clarify the steps for building the omamqp1 plugin rpm

### DIFF
--- a/rpms/v7-el7-rsyslog-omamqp1/README.md
+++ b/rpms/v7-el7-rsyslog-omamqp1/README.md
@@ -11,6 +11,8 @@ For example, if you have a local git repo with the source code in
 $HOME/rsyslog::
 
     $ cd $HOME/rsyslog
+    $ git clean
+    $ autoreconf -fvi
     $ tar cfz $builddir/rsyslog-omamqp1.tar.gz plugins/omamqp1
 
 Build the rsyslog-omamqp1 srpm with the spec file::


### PR DESCRIPTION
The config.status step failed for me the first time I tried to build - I hadn't run autoreconf so the plugin's directory was missing the Makefile.in file.
